### PR TITLE
number invalid if number >= base

### DIFF
--- a/conversions/toDecimal.c
+++ b/conversions/toDecimal.c
@@ -25,8 +25,10 @@ int main(void) {
 		else
 			number[i] = base + 1;
 		
-		if (number[i] > base)
+		if (number[i] >= base){
 			printf("invalid number\n");
+			return 0;
+		}
 	}
 	
 	for (j = 0; j < i; j++) {


### PR DESCRIPTION
In any to decimal conversions number should not be greater than or equal to base.