### PR TITLE
Format specifier for size_t, calloc check

### DIFF
--- a/project_euler/Problem 07/sol.c
+++ b/project_euler/Problem 07/sol.c
@@ -9,12 +9,16 @@ int main(void) {
     const unsigned target = 10001;
 
     sieve = calloc(n, sizeof *sieve);
+    if (!sieve) {
+        return -1;
+    }
+    
     for (i = 2; i < n; i++) {
         if (!sieve[i]) {
             size_t j; 
             count++;
             if (count == target) {
-                printf("%lu\n", i);
+                printf("%zu\n", i);
                 break;
             }
             for (j = i * 2; j < n; j += i) {


### PR DESCRIPTION
The correct format specifier for `size_t` is `%zu`. If C89 support is needed, `%lu` along with a cast to `unsigned long` will suffice.

Also added error checking for calloc.