### PR TITLE
Corrected function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ C
 
 ## Conversions
 	- binary_to_decimal
-	- decimal _to_binary
+	- decimal_to_binary
 	- decimal_to_hexa
 	- decimal_to_octal
 	- to_decimal


### PR DESCRIPTION
Removed extra space from `decimal _to_binary`.

Though the PR might look too small, somebody once told me that any contribution to opensource is never too small.