### PR TITLE
Added a new Algorithm of Multi-programming_with_Fixed_Tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ C
 	- Greatest Common Divisor	
 	- isArmstrong
 	- LongestSubSequence
+	- Multi-programming_with_Fixed_Tasks
 	- palindrome
 	- prime factorization	
 	- QUARTILE

--- a/misc/Multi-programming_with_Fixed_Tasks.cpp
+++ b/misc/Multi-programming_with_Fixed_Tasks.cpp
@@ -1,0 +1,43 @@
+#include<stdio.h>
+#include<conio.h>
+void main()
+{
+int m,p,s,p1;
+int m1[4],i,f,f1=0,f2=0,fra1,fra2,s1;
+clrscr();
+printf("Enter the memory size:");
+scanf_s("%d",&m);
+printf("Enter the no of partitions:");
+scanf_s("%d",&p);
+s=m/p;
+printf("Each partn size is:%d",s);
+printf("\nEnter the no of processes:");
+scanf_s("%d",&p1);
+for(i=0;i<p1;i++)
+{
+printf("\nEnter the memory req for process%d:",i+1);
+scanf_s("%d",&m1[i]);
+if(m1[i]<=s)
+{
+
+printf("\nProcess is allocated in partition%d",i+1);
+fra1=s-m1[i];
+printf("\nInternal fragmentation for process is:%d",fra1);
+f1=f1+fra1;
+}
+else
+{
+printf("\nProcess not allocated in partition%d",i+1);
+s1=m1[i]-s;
+fra2=s-s1;
+f2=f2+fra2;
+printf("\nExternal fragmentation for partition is:%d",fra2);
+}
+}
+printf("\nProcess\tmemory\tallocatedmemory");
+for(i=0;i<p1;i++)
+printf("\n%5d\t%5d\t%5d",i+1,s,m1[i]);
+f=f1+f2;
+printf("\nThe tot no of fragmentation is:%d",f);
+_getch();
+}


### PR DESCRIPTION
**_Multiprogramming with Fixed Number of Tasks (MFT)_** 🔧
The biggest problem with PCP was that processor cycles were wasted whilst the application program made a request for I/O. To improve processor utilization, another OS called Multiprogramming with Fixed number of Tasks (MFT) was introduced.
Multiprogramming implies that a number of programs are resident in memory at any given point of time. Of these, one program is running on a processor. When a program makes a request for I/O its stateis saved and the program is suspended. Control is given to another program and it continues from where it left off. In this fashion, ultimately all programs run to completion after many cycles of running and sleeping.In MFT, many fixed partitions were created at machine startup. The.The sizes of the partitions could vary.Each program would be loaded into a free partition of appropriate size.

MFT was intended to serve as a stop-gap until Multiprogramming with a Variable number of Tasks (MVT), the intended "target" configuration of OS/360, became available in 1967. Early versions of MVT had many problems, so the simpler MFT continued to be used for many years. After introducing new System/370 machines with virtual memory, in 1972 MFT was developed into OS/VS1, the last system of this particular line.
The first version of MFT shared much of the code and architecture with PCP, and was limited to four partitions. It was very cumbersome to run multiple partitions. Many installations used Houston Automatic Spooling Priority (HASP) to mitigate the complexity.
MFT Version II (MFT-II)  shared much more of the Control Program and Scheduler code with MVT, and was much more flexible to run. The maximum number of partitions increased to 52.
Later modifications of MFT-II added sub-tasking, so that the fixed number of tasks was no longer fixed, although the number of partitions did remain a limitation.
Experience indicated that it was not advisable to install MFT on systems with less than 256 KB of memory, which in the 1960s was quite a large amount.
Also referred to as SYS=INT in macro expansions that were system-dependent.
Enjoy !😄 😆 😊 😃  😏 😍 😘 😚 😳 😌 😆 😁 😉 😜 😝 😀 😗 😙 😛 😴 😟 😦 😧 😮 😬 