### PR TITLE
added heap to readme; missing in the master README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ For a full list of all algorithms, please see: [DIRECTORY.md](https://github.com
 		- recursive_traversals
 	- trie
 		- trie
+	- heap
+		- min heap
+		- max heap 
 
 
 ## Searching


### PR DESCRIPTION
Added the heap structure in the README.md file ; it was already implemented but was missing in the doc.