### PR TITLE
Added postOrder and preOrder functions

### DIFF
--- a/data_structures/binary_trees/binary_search_tree.c
+++ b/data_structures/binary_trees/binary_search_tree.c
@@ -245,6 +245,32 @@ void inOrder(node *root)
     }
 }
 
+/** Traversal procedure that can be used for copying the tree
+ * @param root pointer to parent node
+ */
+void preOrder(node *root)
+{
+    if (root != NULL)
+    {
+        printf("\t[ %d ]\t", root->data);
+        preOrder(root->left);
+        preOrder(root->right);
+    }
+}
+
+/** Traversal procedure that can be used for delete the tree
+ * @param root pointer to parent node
+ */
+void postOrder(node *root)
+{
+    if (root != NULL)
+    {
+        postOrder(root->left);
+        postOrder(root->right);
+        printf("\t[ %d ]\t", root->data);
+    }
+}
+
 /** Main funcion */
 int main()
 {


### PR DESCRIPTION
#### Description of Change
Added Preorder and Postorder Traversal functions in Binary Search Tree. In previous version there was only Inorder Traversal. I thought that these operations are also important since they used in various binary search problems like cloning bst (preorder) and deleting bst (postorder)
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C-Plus-Plus/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#New-File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C-Plus-Plus/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C/pull/596"><img src="https://gitpod.io/api/apps/github/pbs/github.com/savolla/C.git/5ff9a40338911391c5795149141c2e90d04487f4.svg" /></a>

