### PR TITLE
Fix: Integer literal is too large to be represented as signed integer…

### DIFF
--- a/hash/hash_sdbm.c
+++ b/hash/hash_sdbm.c
@@ -33,10 +33,10 @@ uint64_t sdbm(const char* s)
  */
 void test_sdbm()
 {
-    assert(sdbm("Hello World") == 12881824461405877380);
+    assert(sdbm("Hello World") == 12881824461405877380U);
     assert(sdbm("Hello World!") == 7903571203300273309);
-    assert(sdbm("Hello world") == 15154913742888948900);
-    assert(sdbm("Hello world!") == 15254999417003201661);
+    assert(sdbm("Hello world") == 15154913742888948900U);
+    assert(sdbm("Hello world!") == 15254999417003201661U);
     printf("Tests passed\n");
 }
 


### PR DESCRIPTION
Fixed the warning integer literal is too large to be represented as singed integer. The file now compiles successfully.

#### Description of Change

In the file hash/hash_sdbm.c the integer literals ( in the line: 36, 38, 39 ) were too large to be signed and were error prone. Simply making them unsigned fixes the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.




<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C/pull/793"><img src="https://gitpod.io/api/apps/github/pbs/github.com/hexqwit/C.git/de911c9e8d43f97e026949f4796be742e733c401.svg" /></a>

