### PR TITLE
[CI - bugfix] remove windows builds

### DIFF
--- a/.github/workflows/awesome_workflow.yml
+++ b/.github/workflows/awesome_workflow.yml
@@ -122,7 +122,7 @@ jobs:
 
             subprocess.run(["clang-tidy-10", "-p=build", "--fix", *cpp_files, "--"],
                 check=True, text=True, stderr=subprocess.STDOUT)
-            
+
             subprocess.run(["clang-format-10", "-i", *cpp_files],
                 check=True, text=True, stderr=subprocess.STDOUT)
 
@@ -155,7 +155,7 @@ jobs:
     needs: [MainSequence]
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, macOS-latest]
     steps:
       - uses: actions/checkout@master
         with:


### PR DESCRIPTION
#### Description of Change
CI checks are repeatedly failing due to non-standard C code in the windows SDK.
This will remove CI build checks on windows OS and thus eliminate the issues.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->
Closes #794 
Closes 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- ~[ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)~
- ~[ ] Added tests and example, test must pass~
- ~[ ] Relevant documentation/comments is changed or added~
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
