### PR TITLE
fix: Added `limits.h` in `data_structures/heap/max_heap.c`

### DIFF
--- a/data_structures/heap/max_heap.c
+++ b/data_structures/heap/max_heap.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/data_structures/heap/max_heap.c
+++ b/data_structures/heap/max_heap.c
@@ -1,5 +1,5 @@
-#include <limits.h>
-#include <stdio.h>
+#include <limits.h> //To define the minimum value for an int
+#include <stdio.h> 
 #include <stdlib.h>
 
 typedef struct max_heap

--- a/data_structures/heap/max_heap.c
+++ b/data_structures/heap/max_heap.c
@@ -1,6 +1,6 @@
-#include <limits.h>  // to define sizes of integral types
-#include <stdio.h>   // for file related input/output functions
-#include <stdlib.h>  // for memory allocation/freeing functions
+#include <limits.h>  /// for INT_MIN
+#include <stdio.h>   /// for IO operations
+#include <stdlib.h>  /// for dynamic memory allocation
 
 typedef struct max_heap
 {

--- a/data_structures/heap/max_heap.c
+++ b/data_structures/heap/max_heap.c
@@ -1,5 +1,9 @@
-#include <limits.h> //To define the minimum value for an int
-#include <stdio.h> 
+/* 
+ * @limits.h defines sizes of integral types.
+ * Constants with the limits of fundamental integral types are defined using this header.
+*/
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 typedef struct max_heap

--- a/data_structures/heap/max_heap.c
+++ b/data_structures/heap/max_heap.c
@@ -1,10 +1,6 @@
-/* 
- * @limits.h defines sizes of integral types.
- * Constants with the limits of fundamental integral types are defined using this header.
-*/
-#include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <limits.h>  // to define sizes of integral types
+#include <stdio.h>   // for file related input/output functions
+#include <stdlib.h>  // for memory allocation/freeing functions
 
 typedef struct max_heap
 {


### PR DESCRIPTION
#### Description of Change
Previously after execution it was throwing error that INT_MIN is not declared. Added limits.h header file to fix that error. 
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->
Closes #758 
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
