### PR TITLE
fix: developer_tools/malloc_debug.c read access violation. see [Issue#850](https://github.com/TheAlgorithms/C/issues/850)

### DIFF
--- a/developer_tools/malloc_dbg.c
+++ b/developer_tools/malloc_dbg.c
@@ -70,54 +70,6 @@ mem_info* addMemInfo(mem_info* memoryInfo, void* ptrToReturn, size_t bytes, int 
 }
 
 /**
- * @brief inList function is used to know if an element is already in the memoryInfo list.
- * @details This function is used to know if an allocation in a specific file at a specific line already exists in the list.
- * @param filename File in which malloc or calloc has been called
- * @param line Line number in the file in which malloc or calloc has been called
- * @returns Position of the element in the list if the element is found, -1 otherwise.
- */
-int inList(const char* filename, int line)
-{
-	mem_info* tmp = memoryInformation;
-	int counter = 0;
-	int len = strlen(filename);
-
-	while (tmp)
-	{
-		if (len == strlen(tmp->fileName))
-		{
-			if (!memcmp(filename, tmp->fileName, len) && tmp->line == line)
-			{
-				return counter;
-			}
-		}
-		tmp = tmp->next;
-		counter++;
-	}
-	return -1;
-}
-
-/**
- * @brief editInfo function is used to edit an element in the memoryInfo list.
- * @details This function is used to edit the number of bytes allocated at a specific line.
- * @param elemPos Position of an element in the doubly linked list memoryInfo
- * @param bytes Size of the allocation in bytes
- * @returns Nothing.
- */
-void editInfo(int elemPos, size_t bytes)
-{
-	int counter = 0;
-	mem_info* tmp = memoryInformation;
-
-	while (counter != elemPos)
-	{
-		tmp = tmp->next;
-		counter++;
-	}
-	tmp->bytes += bytes;
-}
-
-/**
  * @brief malloc_dbg function is a wrapper around the malloc function.
  * @details This function calls malloc and allocates the number of bytes passed in the parameters.
  * If the allocation succeeds then it add the pointer returned by malloc in the mem_info list.
@@ -142,21 +94,14 @@ void* malloc_dbg(size_t bytes, int line, const char* filename, const char* funct
 		atexitCalled = 1;
 	}
 
-	pos = inList(filename, line);
-	if (pos == -1)
+	// Add a new element in the mem_info list
+	memoryInformation = addMemInfo(memoryInformation, ptrToReturn, bytes, line, filename, functionName);
+	if (!memoryInformation)
 	{
-		// Add a new element in the mem_info list
-		memoryInformation = addMemInfo(memoryInformation, ptrToReturn, bytes, line, filename, functionName);
-		if (!memoryInformation)
-		{
-			free(ptrToReturn);
-			return NULL;
-		}
+		free(ptrToReturn);
+		return NULL;
 	}
-	else
-	{
-		editInfo(pos, bytes);
-	}
+
 	return ptrToReturn;
 }
 

--- a/developer_tools/test_malloc_dbg.c
+++ b/developer_tools/test_malloc_dbg.c
@@ -21,11 +21,32 @@
  */
 int main(int argc, char* argv[])
 {
-	int* iptr = malloc(10 * sizeof(int));
-	char* cptr = calloc(256, sizeof(char));
+    // TEST 1
+    int* iptr = malloc(10 * sizeof(int));
+    char* cptr = calloc(256, sizeof(char));
 
-	free(iptr);
-	// free(cptr);
+    free(iptr);
+    // free(cptr);
 
+    // TEST 2
+    // Initialize an array then free it.
+    int* test_list[5] = {NULL};
+
+    for (unsigned i = 0; i < 5; i++)
+    {
+        test_list[i] = malloc(sizeof(int));
+    }
+
+    for (unsigned i = 0; i < 2; i++)
+    {
+        free(test_list[i]);
+    }
+
+    /*
+     * Expected output on exit: 
+     * == == == == == == == == == == == == == == == == == ==
+     * SUMMARY : 
+     * 268 bytes lost in 4 blocks
+    */
 	return 0;
 }


### PR DESCRIPTION


#### Description of Change

Added a complementary test to [test_malloc_dbg.c](https://github.com/TheAlgorithms/C/blob/cc241f58c253c533ac94e07151ef91a5ef7e5719/developer_tools/test_malloc_dbg.c)
Removed the functions inList and editInfo from [malloc_dbg.c](https://github.com/TheAlgorithms/C/blob/cc241f58c253c533ac94e07151ef91a5ef7e5719/developer_tools/malloc_dbg.c), as well as the check of inList in [malloc_dbg()](https://github.com/TheAlgorithms/C/blob/cc241f58c253c533ac94e07151ef91a5ef7e5719/developer_tools/malloc_dbg.c#L145) that would prevent ptrToReturn from being saved in the linked list.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->
Issue #850  : [BUG] read access violation when using developer_tools/malloc_dbg

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
