### PR TITLE
gitpod: don't lock extensions' version

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -11,7 +11,7 @@ github:
 
 vscode:
   extensions:
-    - ms-vscode.cpptools@0.28.3:mjRj37VUK0nY2ZeDXzxOJA==
-    - twxs.cmake@0.0.17:9s7m9CWOr6i6NZ7CNNF4kw==
-    - ms-vscode.cmake-tools@1.4.0:eP3hU/MFme+CcSL21Klk1w==
-    - mhutchie.git-graph@1.23.0:TM9ShNmBn94aUJMJusCJlg==
+    - ms-vscode.cpptools
+    - twxs.cmake
+    - ms-vscode.cmake-tools
+    - mhutchie.git-graph


### PR DESCRIPTION
#### Description of Change

I think there is no need to lock extensions' version.

<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C/pull/915"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

