### PR TITLE
fix: merge sort bug

### DIFF
--- a/sorting/merge_sort.c
+++ b/sorting/merge_sort.c
@@ -68,7 +68,7 @@ void merge(int *a, int l, int r, int n)
         }
     }
 
-    for (c = l; c < r - l + 1; c++) a[c] = b[c];
+    for (c = l; c < r + 1; c++) a[c] = b[c];
 
     free(b);
 }


### PR DESCRIPTION
Merge sort does not work properly. To reproduce the bug input 6, 5, 4, 3, 2, 1 the output would be 2, 3, 1, 4, 5, 6.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [ ] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C/pull/921"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

