### PR TITLE
fix: free the allocated resources in quick sort

### DIFF
--- a/sorting/quick_sort.c
+++ b/sorting/quick_sort.c
@@ -93,5 +93,6 @@ int main()
     printf("Sorted array: ");
     display(arr, n);  // Sorted array : 3 4 7 8 8 9 10 11
     getchar();
+    free(arr);
     return 0;
 }


### PR DESCRIPTION
Free the allocated resources by malloc
#### Description of Change
It is a  good practice and example to always free the allocated resources
<!--

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->


<a href="https://gitpod.io/#https://github.com/TheAlgorithms/C/pull/923"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

