### PR TITLE
Abscissa spelled wrong in line 132 as absicca, again whose plural wil…

### DIFF
--- a/graphics/spirograph.c
+++ b/graphics/spirograph.c
@@ -129,7 +129,7 @@ static inline void glutBitmapString(void *font, char *string)
 /**
  * @brief Function to graph (x,y) points on the OpenGL graphics window.
  *
- * @param x array containing absicca of points (must be pre-allocated)
+ * @param x array containing abscissae of points (must be pre-allocated)
  * @param y array containing ordinates of points (must be pre-allocated)
  * @param N number of points in the arrays
  */


### PR DESCRIPTION
…l be abscissae

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [x] Added tests and example, test must pass
- [x] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
