### PR TITLE
fix: Removed double / unintended free

### DIFF
--- a/data_structures/dynamic_array/dynamic_array.c
+++ b/data_structures/dynamic_array/dynamic_array.c
@@ -18,7 +18,6 @@ void *add(dynamic_array_t *da, const void *value)
     {
         void **newItems =
             realloc(da->items, (da->capacity <<= 1) * sizeof(void **));
-        free(da->items);
 
         da->items = newItems;
     }


### PR DESCRIPTION
#### Description of Change

**Call to free() after realloc() removed, avoiding undefined behavior.**
The call to realloc() already frees the previously allocated memory if necessary.
By the man page of realloc(): _"f the area pointed to was moved, a free(ptr) is done.",_
and free(): _"If free(ptr) has already been called before, undefined behavior occurs."._

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] Added description of change(https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [x ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Removed call to free() after realloc()
