### PR TITLE
chore: add `math` to CMake lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ add_subdirectory(project_euler)
 add_subdirectory(machine_learning)
 add_subdirectory(process_scheduling_algorithms)
 add_subdirectory(numerical_methods)
+add_subdirectory(math)
 
 ## Configure Doxygen documentation system
 cmake_policy(SET CMP0054 NEW)

--- a/math/CMakeLists.txt
+++ b/math/CMakeLists.txt
@@ -1,0 +1,18 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. The RELATIVE flag makes it easier to extract an executable's name
+# automatically.
+
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+foreach( testsourcefile ${APP_SOURCES} )
+    string( REPLACE ".c" "" testname ${testsourcefile} ) # File type. Example: `.c`
+    add_executable( ${testname} ${testsourcefile} )
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/math") # Folder name. Do NOT include `<>`
+
+endforeach( testsourcefile ${APP_SOURCES} )


### PR DESCRIPTION
#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

The `math` directory didn't have a `CMakeLists.txt` and wasn't added as subdirectory in the root `CMakeLists.txt`. So I fixed that

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers --> `math` now builds
