### PR TITLE
changed list length to reflect contents of the list

### DIFF
--- a/data_structures/list/list.c
+++ b/data_structures/list/list.c
@@ -30,13 +30,13 @@ int List_length(L list)
 {
     int n;
     for (n = 0; list; list = list->next) n++;
-    return n;
+    return n - 1;
 }
 
 /* Convert list to array */
 void **List_toArray(L list)
 {
-    int i, n = List_length(list);
+    int i, n = List_length(list) + 1;
     void **array = (void **)malloc((n + 1) * sizeof(*array));
 
     for (i = 0; i < n; i++)


### PR DESCRIPTION
I changed the return value of n in List_length to reflect the number of items inside the list, so a newly initialized list will return a length of 0.  To prevent items in List_toArray from being cut off, I added one back to n at the beginning of the List_toArray function.

#### Description of Change

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Added description of change
- [ ] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Relevant documentation/comments is changed or added
- [ ] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
