### PR TITLE
fix: hexadecimal_to_octal.c

### DIFF
--- a/conversions/hexadecimal_to_octal.c
+++ b/conversions/hexadecimal_to_octal.c
@@ -1,26 +1,25 @@
-/* C program to convert Hexadecimal to Octal number system */
-
 #include <stdio.h>
+#include <string.h>
+
+#define MAX_STR_LEN 17
 
 int main()
 {
-#define MAX_STR_LEN 17
     char hex[MAX_STR_LEN];
-    long long octal, bin, place;
-    int i = 0, rem, val;
+    long long octal = 0ll, bin = 0ll, place = 1ll;
+    int i, rem, val;
 
     /* Input hexadecimal number from user */
     printf("Enter any hexadecimal number: ");
     fgets(hex, MAX_STR_LEN, stdin);
 
-    octal = 0ll;
-    bin = 0ll;
-    place = 0ll;
+    // Remove newline character from the input
+    hex[strcspn(hex, "\n")] = '\0';
 
-    /* Hexadecimal to binary conversion */
+    // Hexadecimal to binary conversion
     for (i = 0; hex[i] != '\0'; i++)
     {
-        bin = bin * place;
+        bin = bin * 10000;
 
         switch (hex[i])
         {
@@ -80,14 +79,11 @@ int main()
             break;
         default:
             printf("Invalid hexadecimal input.");
+            return 1; // Exit the program with an error code
         }
-
-        place = 10000;
     }
 
-    place = 1;
-
-    /* Binary to octal conversion */
+    // Binary to octal conversion
     while (bin > 0)
     {
         rem = bin % 1000;
@@ -127,7 +123,7 @@ int main()
     }
 
     printf("Hexadecimal number = %s\n", hex);
-    printf("Octal number = %lld", octal);
+    printf("Octal number = %lld\n", octal);
 
     return 0;
 }


### PR DESCRIPTION
#### Description of Change
Fix to Issue #1330 
I've made the following changes:

-  Removed the newline character from the input string.

-  Improved the binary to octal conversion loop.

-   Added a return statement after printing an error message for invalid hexadecimal input.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added file name matches [File name guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#File-Name-guidelines)
- [ ] Added tests and example, test must pass
- [ ] Relevant documentation/comments is changed or added
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [ ] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
