### PR TITLE
fix: changed sizeof() argument

### DIFF
--- a/data_structures/dynamic_array/dynamic_array.c
+++ b/data_structures/dynamic_array/dynamic_array.c
@@ -17,7 +17,7 @@ void *add(dynamic_array_t *da, const void *value)
     if (da->size >= da->capacity)
     {
         void **newItems =
-            realloc(da->items, (da->capacity <<= 1) * sizeof(void **));
+            realloc(da->items, (da->capacity <<= 1) * sizeof(void *));
 
         da->items = newItems;
     }


### PR DESCRIPTION
#### Description of Change

Changed the type used when reallocating dynamic array memory to be more correct. This was not an issue previously because `sizeof(void*)`  and `sizeof(void**)` are the same even though this is not guaranteed by standard (I think).

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md
-->

#### References
<!-- Add any reference to previous pull-request or issue -->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
Changed the type used when reallocating dynamic array memory to be more correct.