### PR TITLE
fix: add missing return in removeValueCArray

### DIFF
--- a/data_structures/array/carray.c
+++ b/data_structures/array/carray.c
@@ -68,6 +68,7 @@ int removeValueCArray(CArray *array, int position)
         if (array->array[position] != 0)
         {
             array->array[position] = 0;
+            return SUCCESS;
         }
         else
             return POSITION_EMPTY;


### PR DESCRIPTION
#### removeValueCArray lacks a return statement in one of its branches.
```
int removeValueCArray(CArray *array, int position)
{
    if (position >= 0 && position < array->size)
    {
        if (array->array[position] != 0)
        {
            array->array[position] = 0;
            // here missing.
            return SUCCESS;
        }
        else
            return POSITION_EMPTY;
    }
    return INVALID_POSITION;
}
```
