### PR TITLE
fix: queue null pointer dereference bug

### DIFF
--- a/data_structures/queue/queue.c
+++ b/data_structures/queue/queue.c
@@ -61,8 +61,10 @@ int deque()
         if (head->pre == NULL)
             head = NULL;
         else
+        {
             head = head->pre;
-        head->next = NULL;
+            head->next = NULL;
+        }
     }
     return returnData;
 }


### PR DESCRIPTION
#### Description of Change
Fixed a null pointer dereference issue in the dequeue method. If line 61 (if statement) is true, head will be set to null and line 65 (head->next = null) will be executed which leads to a null pointer dereference issue. An example would be removing a node from a queue that contains a single node. 
Line 66 should be executed in the else statement. Therefore, this fix moves line 66 to be executed in the else statement.

#### References

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Fixed a null pointer dereference bug (Line 65: Dereferencing a pointer after setting it to null) in the code. 
