### PR TITLE
fix: Prevent segmentation fault at Simple generic Stack

### DIFF
--- a/data_structures/stack/stack.c
+++ b/data_structures/stack/stack.c
@@ -45,17 +45,8 @@ void grow()
 {
     max += 10; /* increases the capacity */
 
-    int i;  // for the loop
-    void **tmp = malloc(sizeof(void *) * max);
-
-    /* copies the elements from the origin array in the new one. */
-    for (i = 0; i < max - 10; i++)
-    {
-        *(tmp + i) = *(array + i);
-    }
-    /*free the memory */
-    free(array);
-    array = tmp;
+    array = (void **)realloc(array, sizeof(void *) * max);
+    assert(array); /* tests whether pointer is assigned to memory. */
 }
 
 /* push: pushs the argument onto the stack */


### PR DESCRIPTION
#### Description of Change
- Prevent segmentation fault error at stack.c grow function
  - After malloc, there is an iteration without any check if malloc returned null

#### References

#### Checklist

- [x] Added description of change
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/C/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: Used realloc instead of malloc